### PR TITLE
Pytest warning handling

### DIFF
--- a/climpyrical/gridding.py
+++ b/climpyrical/gridding.py
@@ -307,9 +307,9 @@ def check_find_nearest_index_inputs(data, val):
 
     if val > data.max() or val < data.min():
         warnings.warn(
-            "Value outside of array's range with domain between \
+            "{} is outside of array's domain between \
             {} and {}. A station is outside of the CanRCM4 model grid space."
-            .format(data.min(), data.max())
+            .format(val, data.min(), data.max())
         )
 
 
@@ -369,12 +369,6 @@ def check_find_element_wise_nearest_pos_inputs(x, y, x_obs, y_obs):
     if not np.any(is_ndarray):
         raise TypeError(
             "Please provide data arrays of type {}".format(np.ndarray)
-        )
-    if x.size != 155 or y.size != 130:
-        raise ValueError(
-            "To find the values in the supplied arrays, x and y must have a \
-            size of 155 and 130 respectively. Received {} and {}."
-            .format(x.size, y.size)
         )
     if x_obs.size != y_obs.size:
         raise ValueError(

--- a/climpyrical/gridding.py
+++ b/climpyrical/gridding.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from scipy.interpolate import NearestNDInterpolator
 from pyproj import Transformer, Proj
@@ -209,8 +210,8 @@ def check_transform_coords_inputs(x, y, source_crs, target_crs):
 
     if (
         isinstance(x, np.ndarray)
-        and (np.any(x <= -139.024025))
-        or (np.any(x >= -53.006653))
+        and (np.any(x < -140))
+        or (np.any(x > -52))
     ):
         raise ValueError(
             "A station location is outside of expected bounds in x dim. \
@@ -220,8 +221,8 @@ def check_transform_coords_inputs(x, y, source_crs, target_crs):
 
     if (
         isinstance(y, np.ndarray)
-        and (np.any(y >= 82.511053))
-        or (np.any(y <= 41.631742))
+        and (np.any(y > 83))
+        or (np.any(y < 41))
     ):
         raise ValueError(
             "A station location is outside of expected bounds in y dim. \
@@ -305,9 +306,10 @@ def check_find_nearest_index_inputs(data, val):
         raise TypeError("Please provide a value of type {}".format(float))
 
     if val > data.max() or val < data.min():
-        raise ValueError(
-            "Value is not within supplied array's range with domain between \
-            {} and {}.".format(data.min(), data.max())
+        warnings.warn(
+            "Value outside of array's range with domain between \
+            {} and {}. A station is outside of the CanRCM4 model grid space."
+            .format(data.min(), data.max())
         )
 
 
@@ -368,10 +370,11 @@ def check_find_element_wise_nearest_pos_inputs(x, y, x_obs, y_obs):
         raise TypeError(
             "Please provide data arrays of type {}".format(np.ndarray)
         )
-    if x.size != y.size:
+    if x.size != 155 or y.size != 130:
         raise ValueError(
-            "To find the values in the supplied arrays, the arrays must be \
-            same shape. Received {} and {}.".format(x.size, y.size)
+            "To find the values in the supplied arrays, x and y must have a \
+            size of 155 and 130 respectively. Received {} and {}."
+            .format(x.size, y.size)
         )
     if x_obs.size != y_obs.size:
         raise ValueError(

--- a/climpyrical/tests/test_gridding.py
+++ b/climpyrical/tests/test_gridding.py
@@ -184,12 +184,15 @@ bad_data_a = np.linspace(30, 1, 30)
         (data, "2", False, TypeError),
         (bad_data, 1.0, False, ValueError),
         (bad_data_a, 1.0, False, ValueError),
-        (data, 30.0, False, ValueError),
+        (data, 30.0, "warning", None),
     ],
 )
 def test_check_find_nearest_index_inputs(data, val, passed, error):
     if passed:
         check_find_nearest_index_inputs(data, val)
+    elif passed == "warning":
+        with self.assertWarns(UserWarning):
+            check_find_nearest_index_inputs(data, val)
     else:
         with pytest.raises(error):
             check_find_nearest_index_inputs(data, val)

--- a/climpyrical/tests/test_gridding.py
+++ b/climpyrical/tests/test_gridding.py
@@ -177,25 +177,35 @@ bad_data_a = np.linspace(30, 1, 30)
 
 
 @pytest.mark.parametrize(
-    "data,val,passed,error",
+    "data,val,passed,raises",
     [
         ("data", 1.0, False, TypeError),
         (data, 1.0, True, None),
         (data, "2", False, TypeError),
         (bad_data, 1.0, False, ValueError),
         (bad_data_a, 1.0, False, ValueError),
-        (data, 30.0, "warning", None),
     ],
 )
-def test_check_find_nearest_index_inputs(data, val, passed, error):
+def test_check_find_nearest_index_inputs(data, val, passed, raises):
     if passed:
         check_find_nearest_index_inputs(data, val)
-    elif passed == "warning":
-        with self.assertWarns(UserWarning):
-            check_find_nearest_index_inputs(data, val)
     else:
-        with pytest.raises(error):
+        with pytest.raises(raises):
             check_find_nearest_index_inputs(data, val)
+
+
+@pytest.mark.parametrize(
+    "data,val,passed,warning",
+    [
+        (data, 25.0, True, None),
+        (data, 35.0, False, UserWarning)
+    ],
+)
+def test_check_find_nearest_index_inputs_warnings(data, val, passed, warning):
+    if passed:
+        check_find_nearest_index_inputs(data, val)
+    with pytest.warns(warning):
+        check_find_nearest_index_inputs(data, val)
 
 
 @pytest.mark.parametrize(
@@ -211,24 +221,16 @@ def test_find_nearest_index(data, val, expected):
     [
         ("x", 1, 2, 3, False, TypeError),
         (
-            np.linspace(-10, 10, 10),
-            np.linspace(-10, 10, 9),
-            np.linspace(-10, 10, 10),
-            np.linspace(-10, 10, 10),
-            False,
-            ValueError,
-        ),
-        (
-            np.linspace(-10, 10, 10),
-            np.linspace(-10, 10, 10),
+            np.linspace(-10, 10, 155),
+            np.linspace(-10, 10, 130),
             np.linspace(-10, 10, 10),
             np.linspace(-10, 10, 9),
             False,
             ValueError,
         ),
         (
-            np.linspace(-10, 10, 10),
-            np.linspace(-10, 10, 10),
+            np.linspace(-10, 10, 155),
+            np.linspace(-10, 10, 130),
             np.linspace(-10, 10, 10),
             np.linspace(-10, 10, 10),
             True,
@@ -247,7 +249,7 @@ def test_check_find_element_wise_nearest_pos_inputs(
 
 
 @pytest.mark.parametrize(
-    "x,y,x_obs,y_obs,expected",
+    "x,y,x_obs,y_obs,expected_x,expected_y",
     [
         (
             np.linspace(-10, 10, 20),
@@ -255,13 +257,16 @@ def test_check_find_element_wise_nearest_pos_inputs(
             np.linspace(-10, 10, 20),
             np.linspace(-10, 10, 20),
             np.array(range(20)),
+            np.array(range(20))
         )
     ],
 )
-def test_find_element_wise_nearest_pos(x, y, x_obs, y_obs, expected):
+def test_find_element_wise_nearest_pos(
+        x, y, x_obs, y_obs, expected_x, expected_y
+):
     xclose, yclose = find_element_wise_nearest_pos(x, y, x_obs, y_obs)
-    xclose_truth = np.allclose(xclose, expected)
-    yclose_truth = np.allclose(yclose, expected)
+    xclose_truth = np.allclose(xclose, expected_x)
+    yclose_truth = np.allclose(yclose, expected_y)
     assert xclose_truth and yclose_truth
 
 


### PR DESCRIPTION
I've discovered that a few of my `checks` in my check functions are a bit too harsh, and that I need to soften their requirements. This will allow a more flexible use of a few functions (specifically, `find_nearest_index` ). 

One such change on this PR is to raise a warning using `pytest` instead of an exception. In this particular case, there are stations outside of the CanRCM4 model grid space, causing an error to be risen in my check functions. I don't want this to raise an error since this is a probable scenario - especially in northern stations, so instead, I want to raise a `UserWarning` with a similar message. 