### PR TITLE
Feature/soften_mask_tests

### DIFF
--- a/climpyrical/mask.py
+++ b/climpyrical/mask.py
@@ -1,3 +1,4 @@
+from climpyrical.gridding import check_ndims
 import numpy as np
 from shapely.geometry import Point
 import geopandas as gpd
@@ -7,8 +8,9 @@ def check_polygon_validity(p):
     """Checks that the polygon provided is valid
     Args:
         p: polygon of type geopandas.GeoSeries
-    Returns:
-        bool for passing the checker
+    Raises:
+        TypeError: for wrong type
+        ValueError: for GeoDataFrame that is empty or invalid values
     """
     if not isinstance(p, gpd.GeoSeries):
         raise TypeError("Must be gpd.GeoSeries, not {}".format(type(p)))
@@ -78,29 +80,10 @@ def check_input_grid_coords(x, y):
             "Please provide an object of type {}".format(np.ndarray)
         )
 
-    # set tolerances loosely so coordinates within an absolute
-    # tolerance of the len/width of one grid cell are still
-    # permitted. This is done so re-gridding can occur without
-    # raising an error here.
-    xtol = np.mean(np.diff(x))
-    ytol = np.mean(np.diff(y))
+    check_ndims(x, 1)
+    check_ndims(y, 1)
 
-    if (not np.isclose(x.max(), 33.8800048828125, atol=xtol)) or (
-        not np.isclose(x.min(), -33.8800048828125, atol=xtol)
-    ):
-        raise ValueError("Unexpected range of values in x dimension")
-    if (not np.isclose(y.max(), 28.15999984741211, atol=ytol)) or (
-        not np.isclose(y.min(), -28.59999656677246, atol=ytol)
-    ):
-        raise ValueError("Unexpected range of values in y dimension")
-    if (x.size != 155 or y.size != 130) and (
-        x.size % 155 != 0 or y.size % 130 != 0
-    ):
-        raise ValueError(
-            "Longitude and latitude expected size 155 and 130 respectively."
-        )
     return True
-
 
 def rotate_shapefile(
     p,

--- a/climpyrical/mask.py
+++ b/climpyrical/mask.py
@@ -85,6 +85,7 @@ def check_input_grid_coords(x, y):
 
     return True
 
+
 def rotate_shapefile(
     p,
     crs={

--- a/climpyrical/tests/test_mask.py
+++ b/climpyrical/tests/test_mask.py
@@ -70,7 +70,7 @@ def test_check_polygon_validity(p, error):
     [
         (canada, None),
         (rotated_canada, ValueError),
-        (transformed_world, ValueError)
+        (transformed_world, ValueError),
     ],
 )
 def test_check_polygon_before_projection(p, error):
@@ -107,7 +107,7 @@ def test_check_polygon_after_projection(p, error):
         (np.linspace(-24, 24, 155), "y", TypeError),
         (np.ones((2, 2)), np.linspace(-24, 24, 155), ValueError),
         (np.linspace(-24, 24, 155), np.ones((2, 2)), ValueError),
-        (np.linspace(-24, 24, 155), np.linspace(-24, 24, 155), None)
+        (np.linspace(-24, 24, 155), np.linspace(-24, 24, 155), None),
     ],
 )
 def test_check_input_grid_coords(x, y, error):

--- a/climpyrical/tests/test_mask.py
+++ b/climpyrical/tests/test_mask.py
@@ -45,89 +45,76 @@ good_polygon = gpd.read_file(
 
 
 @pytest.mark.parametrize(
-    "p,passed",
+    "p,error",
     [
-        ({"string"}, False),
-        ({5}, False),
-        (canada, True),
-        (rotated_canada, True),
-        (transformed_world, True),
-        (good_polygon, True),
-        (bad_polygon, False),
-        (gpd.GeoSeries(), False),
+        ({"string"}, TypeError),
+        ({5}, TypeError),
+        (canada, None),
+        (rotated_canada, None),
+        (transformed_world, None),
+        (good_polygon, None),
+        (bad_polygon, ValueError),
+        (gpd.GeoSeries(), ValueError),
     ],
 )
-def test_check_polygon_validity(p, passed):
-    if passed:
-        assert check_polygon_validity(p)
+def test_check_polygon_validity(p, error):
+    if error is None:
+        check_polygon_validity(p)
     else:
-        with pytest.raises((TypeError, ValueError)):
+        with pytest.raises(error):
             check_polygon_validity(p)
 
 
 @pytest.mark.parametrize(
-    "p,passed",
-    [(canada, True), (rotated_canada, False), (transformed_world, False)],
+    "p,error",
+    [
+        (canada, None),
+        (rotated_canada, ValueError),
+        (transformed_world, ValueError)
+    ],
 )
-def test_check_polygon_before_projection(p, passed):
-    if passed:
-        assert check_polygon_before_projection(p)
+def test_check_polygon_before_projection(p, error):
+    if error is None:
+        check_polygon_before_projection(p)
     else:
-        with pytest.raises((TypeError, ValueError)):
+        with pytest.raises(error):
             check_polygon_before_projection(p)
 
 
 @pytest.mark.parametrize(
-    "p,passed",
+    "p,error",
     [
-        ({"string"}, False),
-        ({5}, False),
-        (canada, False),
-        (rotated_canada, True),
-        (transformed_world, False),
-        (gpd.GeoSeries(), False),
+        ({"string"}, TypeError),
+        ({5}, TypeError),
+        (canada, ValueError),
+        (rotated_canada, None),
+        (transformed_world, ValueError),
+        (gpd.GeoSeries(), ValueError),
     ],
 )
-def test_check_polygon_after_projection(p, passed):
-    if passed:
-        assert check_polygon_after_projection(p)
+def test_check_polygon_after_projection(p, error):
+    if error is None:
+        check_polygon_after_projection(p)
     else:
-        with pytest.raises((TypeError, ValueError)):
+        with pytest.raises(error):
             check_polygon_after_projection(p)
 
 
 @pytest.mark.parametrize(
-    "x,y,passed",
+    "x,y,error",
     [
-        ("x", np.linspace(-24, 24, 155), False),
-        (np.linspace(-24, 24, 155), "y", False),
-        (
-            np.linspace(0, 10, 30),
-            np.linspace(-28.59999656677246, 28.15999984741211, 130),
-            False,
-        ),
-        (
-            np.linspace(-33.8800048828125, 33.8800048828125, 155),
-            np.linspace(0, 10, 130),
-            False,
-        ),
-        (
-            np.linspace(-33.8800048828125, 33.8800048828125, 155),
-            np.linspace(-28.59999656677246, 28.15999984741211, 130),
-            True,
-        ),
-        (
-            np.linspace(-33.8800048828125, 33.8800048828125, 15),
-            np.linspace(-28.59999656677246, 28.15999984741211, 10),
-            False,
-        ),
+        ("x", np.linspace(-24, 24, 155), TypeError),
+        (np.linspace(-24, 24, 155), "y", TypeError),
+        (np.ones((2, 2)), np.linspace(-24, 24, 155), ValueError),
+        (np.linspace(-24, 24, 155), np.ones((2, 2)), ValueError),
+        (np.linspace(-24, 24, 155), np.linspace(-24, 24, 155), None)
     ],
 )
-def test_check_input_grid_coords(x, y, passed):
-    if passed:
-        assert check_input_grid_coords(x, y)
+def test_check_input_grid_coords(x, y, error):
+    if error is None:
+        check_input_grid_coords(x, y)
     else:
-        with pytest.raises((ValueError, TypeError)):
+        with pytest.raises(error):
             check_input_grid_coords(x, y)
 
 


### PR DESCRIPTION
This PR aims to soften some of the strict masking tests imposed, and opts for checking things like the dimensionality of an array instead of its exact shape and range of values. This is so that masking functions can take an arbitrarily shaped `xarray.DataSet` and apply a mask to the raster data given a polygon. 

The previous PR, #20, where I've updated the interpolation method also tries to soften this, but after incorporating #20, I've realized it doesn't account for some use-cases without complicating the parameters used. For example, what if we want to mask a newly gridded dataset using climpyrical's masking functions? The previously strict checks are not flexible enough to account for this.

This PR also improves the testing functions to check precisely which error should be raised when parametrized - a design that already exists in other `climpyrical` functions. 

TL;DR:
* Softens mask checking to type and dimensionality only instead of range and shape
* Takes one step closer to accepting arbitrary climate models of new locations for the NRC method. (This is untested since there is no realistic or available data for this that I'm aware and is probably a low priority. )
* Improves expressiveness of test parameters