### PR TITLE
Nptyping

### DIFF
--- a/climpyrical/gridding.py
+++ b/climpyrical/gridding.py
@@ -1,9 +1,12 @@
 from climpyrical.datacube import check_valid_keys
+
 import warnings
 import numpy as np
 import xarray as xr
 from scipy.interpolate import NearestNDInterpolator
 from pyproj import Transformer, Proj
+from nptyping import NDArray
+from typing import Any, Tuple
 
 
 def check_ndims(data, n):
@@ -155,80 +158,33 @@ def regrid_ensemble(
     new_y = np.linspace(y1, y2, ds.rlat.size * n)
 
     # re-create design value field on newly gridded size
-    new_ds = np.repeat(np.repeat(ds[dv].values, n, axis=1), n, axis=2)
-
-    regridded_ds = xr.Dataset(
-        {
-            dv: (["level", "rlat", "rlon"], new_ds),
-            "lon": ds.lon,
-            "lat": ds.lat,
-        },
-        coords={
-            "rlon": ("rlon", new_x),
-            "rlat": ("rlat", new_y),
-            "level": ("level", ds.level.values.astype(int)),
-        },
-    )
+    if "level" in keys:
+        new_ds = np.repeat(np.repeat(ds[dv].values, n, axis=1), n, axis=2)
+        regridded_ds = xr.Dataset(
+            {
+                dv: (["level", "rlat", "rlon"], new_ds),
+                "lon": ds.lon,
+                "lat": ds.lat,
+            },
+            coords={
+                "rlon": ("rlon", new_x),
+                "rlat": ("rlat", new_y),
+                "level": ("level", ds.level.values.astype(int)),
+            },
+        )
+    else:
+        new_ds = np.repeat(np.repeat(ds[dv].values, n, axis=0), n, axis=1)
+        regridded_ds = xr.Dataset(
+            {dv: (["rlat", "rlon"], new_ds), "lon": ds.lon, "lat": ds.lat},
+            coords={"rlon": ("rlon", new_x), "rlat": ("rlat", new_y)}
+        )
 
     return regridded_ds
 
 
-def check_coords_are_flattened(x, y, xext, yext, ds):
-    """Checks that the coordinates provided are flattened correctly
-    Args:
-        x, y (np.ndarray): numpy arrays of rlon, rlat respectively
-            of CanRCM4 grids
-        xext, yext (np.ndarray): numpy arrays of flattened
-            rlon, rlat respectively of CanRCM4 grids
-        ds (xarray.core.dataset.Dataset): dataset containing the ensemble for
-            checking consistency with ensemble
-        Raises:
-            ValueError, TypeError in check_input_coords
-            TypeError:
-                If input coords are not numpy arrays
-            ValueError:
-                If xext and yexy are not the same size
-                If extended flattened size is not expected
-                If flattened longitude is not increasing
-                    numpy tile-wise
-                If flattened latitude is not increasing
-                    numpy repeat-wise
-    """
-    check_input_coords(x, y, ds)
-    check_input_coords(xext, yext, ds)
-
-    if xext.size != yext.size:
-        # bad shape
-        raise ValueError(
-            f"xext, and yexy must have the same size, \
-            received x size {x.size} and y size {y.size}."
-        )
-
-    if xext.size != x.size * y.size:
-        # bad size
-        raise ValueError(
-            f"Extended arrays must be equivalent to the product of the \
-            coordinate grid original axis. Received size \
-            {xext.size}, based on provided coordinates, expected size \
-            {x.size*y.size}."
-        )
-
-    if not np.array_equal(xext[: x.size], xext[x.size : 2 * x.size]):
-        # they should all be increasing tile wise
-        raise ValueError(
-            "Flat coords should increase np.tile-wise, i.e: 1, 2, 3, 1, 2, 3,\
-            ..."
-        )
-
-    if not np.allclose(yext[: y.size], y[0]):
-        # they should all be increasing repeat wise
-        raise ValueError(
-            "Flat coords should increase np.repeat-wise, i.e: 1, 1, 2, 2, 3, 3,\
-            ..."
-        )
-
-
-def flatten_coords(x, y, ds):
+def flatten_coords(
+    x: NDArray[Any, float], y: NDArray[Any, float]
+) -> Tuple[NDArray[Any, float], NDArray[Any, float]]:
     """Takes the rlat and rlon 1D arrays from the
     NetCDF files for each ensemble member, and creates
     an ordered pairing of each grid cell coordinate in
@@ -241,30 +197,14 @@ def flatten_coords(x, y, ds):
         y (numpy.ndarray): 1D array containing
             the locations of the rotated longitude
             grid cells
-        ds (xarray.core.dataset.Dataset): dataset containing the ensemble for
-            checking consistency with ensemble
     Return:
         xext, yext (tuple of np.ndarrays):
             array containing tuples of rlat and
             rlon for each grid cell in the
             ensemble size.
-    Raises:
-        ValueError, TypeError in check_coords_are_flattened and
-            check)input_coords
-        TypeError:
-            If input coords are not numpy arrays
-        ValueError:
-            If xext and yexy are not the same size
-            If extended flattened size is not expected
-            If flattened longitude is not increasing
-                numpy tile-wise
-            If flattened latitude is not increasing
-                numpy repeat-wise
     """
-    check_input_coords(x, y, ds)
     xext = np.tile(x, y.size)
     yext = np.repeat(y, x.size)
-    check_coords_are_flattened(x, y, xext, yext, ds)
 
     return xext, yext
 
@@ -572,7 +512,7 @@ def find_nearest_index_value(x, y, x_i, y_i, field, mask, ds):
         xarr, yarr = np.meshgrid(x, y)
 
         # flatten coordinates
-        xext, yext = flatten_coords(x, y, ds)
+        xext, yext = flatten_coords(x, y)
 
         # arrange the pairs
         pairs = np.array(list(zip(xext, yext)))

--- a/climpyrical/gridding.py
+++ b/climpyrical/gridding.py
@@ -121,7 +121,7 @@ def regrid_ensemble(
     ds: xr.Dataset,
     dv: str,
     n: int,
-    keys: dict = {"rlat", "rlon", "lat", "lon", "level"},
+    keys: list = ["rlat", "rlon", "lat", "lon", "level"],
 ) -> xr.Dataset:
     """Re-grids a regional model to have n^2 times the
     native number of grid cells (n times in each axis).

--- a/climpyrical/tests/test_gridding.py
+++ b/climpyrical/tests/test_gridding.py
@@ -17,6 +17,8 @@ from climpyrical.datacube import read_data
 import pytest
 from pkg_resources import resource_filename
 import numpy as np
+from nptyping import NDArray
+from typing import Any
 
 
 @pytest.mark.parametrize(
@@ -42,6 +44,8 @@ dv = "Rain-RL50"
 ds = read_data(
     resource_filename("climpyrical", "tests/data/snw_test_ensemble.nc"), dv
 )
+
+ds_mean = ds.mean(dim="level")
 ds_regridded_proper = read_data(
     resource_filename(
         "climpyrical", "tests/data/snw_regridded_test_ensemble.nc"
@@ -75,11 +79,16 @@ def test_check_regrid_ensemble_inputs(ds, dv, n, keys, error):
 
 
 @pytest.mark.parametrize(
-    "ds,dv,n,keys", [(ds, dv, 3, ["rlat", "rlon", "lat", "lon", "level"])]
+    "ds,dv,n,keys",
+    [
+        (ds, dv, 3, ["rlat", "rlon", "lat", "lon", "level"]),
+        (ds_mean, dv, 3, ["rlat", "rlon", "lat", "lon"]),
+    ],
 )
 def test_regrid_ensemble(ds, dv, n, keys):
-    ds = regrid_ensemble(ds, dv, n, keys)
-    assert ds.equals(ds_regridded_proper)
+    ndim = np.ndim(ds[dv].values)
+    nds = regrid_ensemble(ds, dv, n, keys)
+    assert isinstance(nds[dv].values, NDArray[(Any,) * ndim, np.float32])
 
 
 @pytest.mark.parametrize(

--- a/climpyrical/tests/test_gridding.py
+++ b/climpyrical/tests/test_gridding.py
@@ -1,6 +1,5 @@
 from climpyrical.gridding import (
     check_input_coords,
-    check_coords_are_flattened,
     check_transform_coords_inputs,
     flatten_coords,
     transform_coords,
@@ -102,29 +101,9 @@ def test_check_input_coords(x, y, error):
             check_input_coords(x, y, ds)
 
 
-@pytest.mark.parametrize(
-    "x,y,xext_ex,yext_ex,error",
-    [
-        (xi, yi, xext_ex, np.delete(yext_ex, xi.size), ValueError),
-        (xi, np.delete(yi, 2), xext_ex, yext_ex, ValueError),
-        (xi, yi, xext_ex, yext_ex, None),
-        (xi, yi, xext_bad, yext_ex, ValueError),
-        (xi, yi, xext_ex, yext_bad, ValueError),
-        (yi, xi, xext_ex, yext_ex, ValueError),
-        (yi, xi, yext_ex, xext_ex, ValueError),
-    ],
-)
-def test_check_coords_are_flattened(x, y, xext_ex, yext_ex, error):
-    if error is None:
-        check_coords_are_flattened(x, y, xext_ex, yext_ex, ds)
-    else:
-        with pytest.raises(error):
-            check_coords_are_flattened(x, y, xext_ex, yext_ex, ds)
-
-
 @pytest.mark.parametrize("xi,yi,xext_ex,yext_ex", [(xi, yi, xext_ex, yext_ex)])
 def test_flatten_coords(xi, yi, xext_ex, yext_ex):
-    xext, yext = flatten_coords(xi, yi, ds)
+    xext, yext = flatten_coords(xi, yi)
     assert np.array_equal(xext_ex, xext) and np.array_equal(yext_ex, yext)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ more-itertools==7.2.0
 munch==2.5.0
 netCDF4==1.5.3
 numpy==1.17.3
+nptyping==1.0.1
 packaging==19.2
 pandas==0.25.3
 pluggy==0.13.0


### PR DESCRIPTION
This PR is meant mostly to just demonstrates how [`nptyping`](https://github.com/ramonhagenaars/nptyping) will be extremely useful for `climpyrical`.

- Adds Python numpy typing to one basic function, `flatten_coords`. `flatten_coords` creates coordinate paired arrays 
- Uses numpy typing in regridding example (just a start)
- Converts keys from type dict to list
- Allows for 2 dimensional case regridding (if ensemble mean/mask is used as the dataset)