### PR TITLE
Remove scaling individual windows

### DIFF
--- a/climpyrical/rkrig.py
+++ b/climpyrical/rkrig.py
@@ -164,7 +164,7 @@ def rkrig_r(
         kriged field
     """
 
-    dataframe_keys = ["lat", "lon", "rlat", "rlon", station_dv, "model_vals", "ratio"]
+    dataframe_keys = ["lat", "lon", "rlat", "rlon", "ratio"]
     check_df(df, dataframe_keys)
 
     X_distances = np.stack([np.deg2rad(df.lat.values), np.deg2rad(df.lon.values)])
@@ -172,7 +172,7 @@ def rkrig_r(
     dy = (np.amax(ds.rlat.values) - np.amin(ds.rlat.values)) / ds.rlat.size
     dA = dx * dy
 
-    xyr = df[["rlon", "rlat", "model_vals", station_dv]].values
+    xyr = df[["rlon", "rlat", "ratio"]].values
 
     # used to calculate average at end
     field = np.ones((ds.rlat.size, ds.rlon.size))

--- a/docs/rkrig.html
+++ b/docs/rkrig.html
@@ -90,9 +90,7 @@ def krigit_north(
     # rather than rotated coordinates, was that this particular haversine
     # implementation gives incorrect values for rotated lon and rotated lat.
     # it does give correct distances for regular lat and lon.
-    nbrs = NearestNeighbors(n_neighbors=n, metric=&#34;haversine&#34;).fit(
-        regular_points
-    )
+    nbrs = NearestNeighbors(n_neighbors=n, metric=&#34;haversine&#34;).fit(regular_points)
     dist, ind = nbrs.kneighbors(regular_points)
     imax = np.argmax(df.rlat.values)  # idxmax(axis=0, skipna=True)
     temp_df = df.iloc[ind[imax]]
@@ -175,11 +173,7 @@ def rkrig_py(
 
 
 def rkrig_r(
-    df: pd.DataFrame,
-    n: int,
-    ds: xr.Dataset,
-    station_dv: str,
-    min_size: int = 30,
+    df: pd.DataFrame, n: int, ds: xr.Dataset, station_dv: str, min_size: int = 30
 ):
     &#34;&#34;&#34;Implements climpyricals moving window method.
     Args:
@@ -198,25 +192,15 @@ def rkrig_r(
         kriged field
     &#34;&#34;&#34;
 
-    dataframe_keys = [
-        &#34;lat&#34;,
-        &#34;lon&#34;,
-        &#34;rlat&#34;,
-        &#34;rlon&#34;,
-        station_dv,
-        &#34;model_vals&#34;,
-        &#34;ratio&#34;,
-    ]
+    dataframe_keys = [&#34;lat&#34;, &#34;lon&#34;, &#34;rlat&#34;, &#34;rlon&#34;, &#34;ratio&#34;]
     check_df(df, dataframe_keys)
 
-    X_distances = np.stack(
-        [np.deg2rad(df.lat.values), np.deg2rad(df.lon.values)]
-    )
+    X_distances = np.stack([np.deg2rad(df.lat.values), np.deg2rad(df.lon.values)])
     dx = (np.amax(ds.rlon.values) - np.amin(ds.rlon.values)) / ds.rlon.size
     dy = (np.amax(ds.rlat.values) - np.amin(ds.rlat.values)) / ds.rlat.size
     dA = dx * dy
 
-    xyr = df[[&#34;rlon&#34;, &#34;rlat&#34;, &#34;model_vals&#34;, station_dv]].values
+    xyr = df[[&#34;rlon&#34;, &#34;rlat&#34;, &#34;ratio&#34;]].values
 
     # used to calculate average at end
     field = np.ones((ds.rlat.size, ds.rlon.size))
@@ -242,9 +226,9 @@ def rkrig_r(
 
                 while hull.area &lt; dA * min_size ** 2:
                     nn += 1
-                    nbrs = NearestNeighbors(
-                        n_neighbors=nn, metric=&#34;haversine&#34;
-                    ).fit(X_distances.T)
+                    nbrs = NearestNeighbors(n_neighbors=nn, metric=&#34;haversine&#34;).fit(
+                        X_distances.T
+                    )
                     dist, ind = nbrs.kneighbors(X_distances.T)
 
                     temp_xyr = xyr[ind[i], :]
@@ -274,7 +258,7 @@ def krig_at_field(
     windows in the moving window algorithm.
         Args:
             ds: model xarray dataset
-            temp_xyr: subset of station ratios/station values
+            temp_xyr: subset of station ratios
                 from which the kriging is calculated. This array
                 must contain [longitudes, latitudes, ratios]
         Returns:
@@ -285,21 +269,8 @@ def krig_at_field(
     ymin, ymax = temp_xyr[:, 1].min(), temp_xyr[:, 1].max()
 
     latlon = temp_xyr[:, :2].T
-    model_vals = temp_xyr[:, 2]
-    station_vals = temp_xyr[:, 3]
 
-    start = np.mean(model_vals) / np.mean(station_vals)
-    tol = np.linspace(0.01, start * 5, 50000)
-
-    diff = np.array([np.mean(station_vals - model_vals / t) for t in tol])
-
-    best_tol = tol[np.where(np.diff(np.sign(diff)))[0][0]]
-    assert np.isclose(
-        np.mean(station_vals - model_vals / best_tol), 0.0, atol=0.1
-    )
-
-    # stats = temp_xyr[:, 2]
-    stats = station_vals / (model_vals / best_tol)
+    stats = temp_xyr[:, 2]
 
     lw, u = (
         find_nearest_index(ds.rlat.values, ymin),
@@ -354,7 +325,7 @@ as the dataset's design value field. This produces individual
 windows in the moving window algorithm.
 Args:
 ds: model xarray dataset
-temp_xyr: subset of station ratios/station values
+temp_xyr: subset of station ratios
 from which the kriging is calculated. This array
 must contain [longitudes, latitudes, ratios]
 Returns:
@@ -372,7 +343,7 @@ kriged subset field</p></div>
     windows in the moving window algorithm.
         Args:
             ds: model xarray dataset
-            temp_xyr: subset of station ratios/station values
+            temp_xyr: subset of station ratios
                 from which the kriging is calculated. This array
                 must contain [longitudes, latitudes, ratios]
         Returns:
@@ -383,21 +354,8 @@ kriged subset field</p></div>
     ymin, ymax = temp_xyr[:, 1].min(), temp_xyr[:, 1].max()
 
     latlon = temp_xyr[:, :2].T
-    model_vals = temp_xyr[:, 2]
-    station_vals = temp_xyr[:, 3]
 
-    start = np.mean(model_vals) / np.mean(station_vals)
-    tol = np.linspace(0.01, start * 5, 50000)
-
-    diff = np.array([np.mean(station_vals - model_vals / t) for t in tol])
-
-    best_tol = tol[np.where(np.diff(np.sign(diff)))[0][0]]
-    assert np.isclose(
-        np.mean(station_vals - model_vals / best_tol), 0.0, atol=0.1
-    )
-
-    # stats = temp_xyr[:, 2]
-    stats = station_vals / (model_vals / best_tol)
+    stats = temp_xyr[:, 2]
 
     lw, u = (
         find_nearest_index(ds.rlat.values, ymin),
@@ -478,9 +436,7 @@ field: kriged field for the north</p></div>
     # rather than rotated coordinates, was that this particular haversine
     # implementation gives incorrect values for rotated lon and rotated lat.
     # it does give correct distances for regular lat and lon.
-    nbrs = NearestNeighbors(n_neighbors=n, metric=&#34;haversine&#34;).fit(
-        regular_points
-    )
+    nbrs = NearestNeighbors(n_neighbors=n, metric=&#34;haversine&#34;).fit(regular_points)
     dist, ind = nbrs.kneighbors(regular_points)
     imax = np.argmax(df.rlat.values)  # idxmax(axis=0, skipna=True)
     temp_df = df.iloc[ind[imax]]
@@ -619,11 +575,7 @@ the perimeter of stations in a nearest neighbor set</dd>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def rkrig_r(
-    df: pd.DataFrame,
-    n: int,
-    ds: xr.Dataset,
-    station_dv: str,
-    min_size: int = 30,
+    df: pd.DataFrame, n: int, ds: xr.Dataset, station_dv: str, min_size: int = 30
 ):
     &#34;&#34;&#34;Implements climpyricals moving window method.
     Args:
@@ -642,25 +594,15 @@ the perimeter of stations in a nearest neighbor set</dd>
         kriged field
     &#34;&#34;&#34;
 
-    dataframe_keys = [
-        &#34;lat&#34;,
-        &#34;lon&#34;,
-        &#34;rlat&#34;,
-        &#34;rlon&#34;,
-        station_dv,
-        &#34;model_vals&#34;,
-        &#34;ratio&#34;,
-    ]
+    dataframe_keys = [&#34;lat&#34;, &#34;lon&#34;, &#34;rlat&#34;, &#34;rlon&#34;, &#34;ratio&#34;]
     check_df(df, dataframe_keys)
 
-    X_distances = np.stack(
-        [np.deg2rad(df.lat.values), np.deg2rad(df.lon.values)]
-    )
+    X_distances = np.stack([np.deg2rad(df.lat.values), np.deg2rad(df.lon.values)])
     dx = (np.amax(ds.rlon.values) - np.amin(ds.rlon.values)) / ds.rlon.size
     dy = (np.amax(ds.rlat.values) - np.amin(ds.rlat.values)) / ds.rlat.size
     dA = dx * dy
 
-    xyr = df[[&#34;rlon&#34;, &#34;rlat&#34;, &#34;model_vals&#34;, station_dv]].values
+    xyr = df[[&#34;rlon&#34;, &#34;rlat&#34;, &#34;ratio&#34;]].values
 
     # used to calculate average at end
     field = np.ones((ds.rlat.size, ds.rlon.size))
@@ -686,9 +628,9 @@ the perimeter of stations in a nearest neighbor set</dd>
 
                 while hull.area &lt; dA * min_size ** 2:
                     nn += 1
-                    nbrs = NearestNeighbors(
-                        n_neighbors=nn, metric=&#34;haversine&#34;
-                    ).fit(X_distances.T)
+                    nbrs = NearestNeighbors(n_neighbors=nn, metric=&#34;haversine&#34;).fit(
+                        X_distances.T
+                    )
                     dist, ind = nbrs.kneighbors(X_distances.T)
 
                     temp_xyr = xyr[ind[i], :]


### PR DESCRIPTION
Adding Krig-time Scaling only smoothed our overall final ratio field, and we want to preserve some of it. This branch also brings the notebook pipeline up to date with Charle's naming standards.