### PR TITLE
Special case for R15m10

### DIFF
--- a/notebooks/interactive/MWOrK.ipynb
+++ b/notebooks/interactive/MWOrK.ipynb
@@ -292,6 +292,11 @@
     "\n",
     "reconstructed_field_strip_mean = np.nanmean(reconstructed_field[selection])\n",
     "combined_ratio_station_mean = np.mean([reconstructed_field_strip_mean, UAA_station_mean])\n",
+    "\n",
+    "if station_dv == \"Gum-LM RL10 (mm)\":\n",
+    "#     UAA_station_mean = df[station_dv].iloc[np.argmax(df.rlat)]\n",
+    "    combined_ratio_station_mean = df[station_dv].iloc[np.argmax(df.rlat)]\n",
+    "\n",
     "reconstructed_field[northern_mask] = combined_ratio_station_mean"
    ]
   },


### PR DESCRIPTION
* R15m10 does not have the normal Resolute station. So we use the best station information available from Baffin Island (or the northernmost station in the set) and assign uniform value to the Upper Arctic Area.